### PR TITLE
Add unit to timeout

### DIFF
--- a/src/Monolog/ElasticLogstashHandler.php
+++ b/src/Monolog/ElasticLogstashHandler.php
@@ -34,7 +34,7 @@ class ElasticLogstashHandler extends \Monolog\Handler\AbstractProcessingHandler
                 [
                     'index' => $this->options['index'],
                     'type' => $this->options['type'],
-                    'timeout' => 50,
+                    'timeout' => '50ms',
                     'body' => json_decode($record['formatted'], true)
                 ]
             );


### PR DESCRIPTION
Resolves unitless timeout issue as shown here:

[See this issue on Unit is missing when using ConnectionSettings() in conjunction with SniffOnConnectionFault() and SniffOnStartup() #1639](https://github.com/elastic/elasticsearch-net/issues/1639)
